### PR TITLE
Move labels and categories to right side of main page

### DIFF
--- a/_includes/archive.html
+++ b/_includes/archive.html
@@ -1,17 +1,21 @@
 <article>
   <header><h1>{{ include.title | default: page.title }}</h1></header>
-  <ul class="archive">
+  <div class="right-side">
+    <ul class="archive">
+      {% for post in site.posts %}
+      <li>
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%Y-%m-%d" }}</time>
+        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      </li>
+      {% endfor %}
+    </ul>
     {% for post in site.posts %}
-    <li>
-      <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%Y-%m-%d" }}</time>
-      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
       {% if post.tags %}
         <div class="tags">{{ post.tags | join: ", " }}</div>
       {% endif %}
       {% if post.categories %}
         <div class="categories">{{ post.categories | join: ", " }}</div>
       {% endif %}
-    </li>
     {% endfor %}
-  </ul>
+  </div>
 </article>

--- a/_includes/home.html
+++ b/_includes/home.html
@@ -1,22 +1,27 @@
 {%- assign posts = paginator.posts | default: site.posts -%}
-{% for post in posts %}
-  <article>
-    {% include meta.html post=post preview=true %}
-    {{ post.excerpt }}
-    <div class="more"><a href="{{ post.url | relative_url }}">read more</a></div>
+<div class="right-side">
+  {% for post in posts %}
+    <article>
+      {% include meta.html post=post preview=true %}
+      {{ post.excerpt }}
+      <div class="more"><a href="{{ post.url | relative_url }}">read more</a></div>
+    </article>
+  {% endfor %}
+
+  {% if paginator.total_pages > 1 %}
+    <footer>
+      {% if paginator.previous_page %}<a href="{{ paginator.previous_page_path | relative_url }}">« newer posts</a>{% else %}<span></span>{% endif %}
+      <span>page {{ paginator.page }} of {{ paginator.total_pages }}</span>
+      {% if paginator.next_page %}<a href="{{ paginator.next_page_path | relative_url }}">older posts »</a>{% else %}<span></span>{% endif %}
+    </footer>
+  {% endif %}
+
+  {% for post in posts %}
     {% if post.tags %}
       <div class="tags">{{ post.tags | join: ", " }}</div>
     {% endif %}
     {% if post.categories %}
       <div class="categories">{{ post.categories | join: ", " }}</div>
     {% endif %}
-  </article>
-{% endfor %}
-
-{% if paginator.total_pages > 1 %}
-  <footer>
-    {% if paginator.previous_page %}<a href="{{ paginator.previous_page_path | relative_url }}">« newer posts</a>{% else %}<span></span>{% endif %}
-    <span>page {{ paginator.page }} of {{ paginator.total_pages }}</span>
-    {% if paginator.next_page %}<a href="{{ paginator.next_page_path | relative_url }}">older posts »</a>{% else %}<span></span>{% endif %}
-  </footer>
-{% endif %}
+  {% endfor %}
+</div>

--- a/assets/css/classes.sass
+++ b/assets/css/classes.sass
@@ -104,3 +104,8 @@
     width: 100%
 
 {% endunless %}
+
+.right-side
+  float: right
+  width: 20%
+  margin-left: 1em

--- a/assets/css/index.sass
+++ b/assets/css/index.sass
@@ -32,3 +32,8 @@ body > footer
   box-shadow: 0 0 .6em rgba($dark, 0.04) inset
 
 {% endunless %}
+
+.right-side
+  float: right
+  width: 20%
+  margin-left: 1em


### PR DESCRIPTION
Move labels and categories to the right side of the main page.

* Modify `_includes/home.html` to wrap the tags and categories divs in a new `right-side` div and update the layout.
* Modify `_includes/archive.html` to wrap the tags and categories divs in a new `right-side` div and update the layout.
* Update `assets/css/index.sass` to add CSS rules for the new `right-side` class.
* Update `assets/css/classes.sass` to add CSS rules for the new `right-side` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/orkung/orkung.github.io/pull/2?shareId=773186f2-df95-4a0f-93b3-61e58083576c).