### PR TITLE
Hide label and category names on main page

### DIFF
--- a/_includes/archive.html
+++ b/_includes/archive.html
@@ -9,21 +9,5 @@
       </li>
       {% endfor %}
     </ul>
-    {% for post in site.posts %}
-      {% if post.tags %}
-        <div class="tags">
-          {% for tag in post.tags %}
-            <a href="{{ site.baseurl }}/tag/{{ tag }}">{{ tag }}</a>{% if forloop.last == false %}, {% endif %}
-          {% endfor %}
-        </div>
-      {% endif %}
-      {% if post.categories %}
-        <div class="categories">
-          {% for category in post.categories %}
-            <a href="{{ site.baseurl }}/category/{{ category }}">{{ category }}</a>{% if forloop.last == false %}, {% endif %}
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endfor %}
   </div>
 </article>

--- a/_includes/home.html
+++ b/_includes/home.html
@@ -15,21 +15,4 @@
       {% if paginator.next_page %}<a href="{{ paginator.next_page_path | relative_url }}">older posts »</a>{% else %}<span></span>{% endif %}
     </footer>
   {% endif %}
-
-  {% for post in posts %}
-    {% if post.tags %}
-      <div class="tags">
-        {% for tag in post.tags %}
-          <a href="{{ site.baseurl }}/tag/{{ tag }}">{{ tag }}</a>{% if forloop.last == false %}, {% endif %}
-        {% endfor %}
-      </div>
-    {% endif %}
-    {% if post.categories %}
-      <div class="categories">
-        {% for category in post.categories %}
-          <a href="{{ site.baseurl }}/category/{{ category }}">{{ category }}</a>{% if forloop.last == false %}, {% endif %}
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endfor %}
 </div>

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,11 +1,5 @@
 <header>
-  {% if include.post.categories.size > 0 and site.minimal != true and include.preview != true %}
-    <div class="categories">{{ include.post.categories | join: ", "  | upcase }}</div>
-  {% endif %}
   <h1><a href="{{ include.post.url | relative_url }}">{{ include.post.title }}</a></h1>
   {%- assign date_format = site.date_format | default: "%B %d, %Y" -%}
   <time datetime="{{ include.post.date | date_to_xmlschema }}">{{ include.post.date | date: date_format }}</time>
-  {% if include.post.tags.size > 0 %}
-    <div class="tags">{{ include.post.tags | join: ", " }}</div>
-  {% endif %}
 </header>


### PR DESCRIPTION
Remove the display of tags and categories from the main page.

* **_includes/home.html**
  - Remove the code that displays tags for each post.
  - Remove the code that displays categories for each post.

* **_includes/meta.html**
  - Remove the code that displays categories for each post.
  - Remove the code that displays tags for each post.

* **_includes/archive.html**
  - Remove the code that displays tags for each post.
  - Remove the code that displays categories for each post.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/orkung/orkung.github.io/pull/4?shareId=a0735d17-1197-481d-850c-fe81df02e874).