### PR TITLE
Move main page to center

### DIFF
--- a/_includes/archive.html
+++ b/_includes/archive.html
@@ -1,13 +1,11 @@
 <article>
   <header><h1>{{ include.title | default: page.title }}</h1></header>
-  <div class="right-side">
-    <ul class="archive">
-      {% for post in site.posts %}
-      <li>
-        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%Y-%m-%d" }}</time>
-        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-      </li>
-      {% endfor %}
-    </ul>
-  </div>
+  <ul class="archive">
+    {% for post in site.posts %}
+    <li>
+      <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%Y-%m-%d" }}</time>
+      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+    </li>
+    {% endfor %}
+  </ul>
 </article>

--- a/_includes/home.html
+++ b/_includes/home.html
@@ -1,18 +1,16 @@
 {%- assign posts = paginator.posts | default: site.posts -%}
-<div class="right-side">
-  {% for post in posts %}
-    <article>
-      {% include meta.html post=post preview=true %}
-      {{ post.excerpt }}
-      <div class="more"><a href="{{ post.url | relative_url }}">read more</a></div>
-    </article>
-  {% endfor %}
+{% for post in posts %}
+  <article>
+    {% include meta.html post=post preview=true %}
+    {{ post.excerpt }}
+    <div class="more"><a href="{{ post.url | relative_url }}">read more</a></div>
+  </article>
+{% endfor %}
 
-  {% if paginator.total_pages > 1 %}
-    <footer>
-      {% if paginator.previous_page %}<a href="{{ paginator.previous_page_path | relative_url }}">« newer posts</a>{% else %}<span></span>{% endif %}
-      <span>page {{ paginator.page }} of {{ paginator.total_pages }}</span>
-      {% if paginator.next_page %}<a href="{{ paginator.next_page_path | relative_url }}">older posts »</a>{% else %}<span></span>{% endif %}
-    </footer>
-  {% endif %}
-</div>
+{% if paginator.total_pages > 1 %}
+  <footer>
+    {% if paginator.previous_page %}<a href="{{ paginator.previous_page_path | relative_url }}">« newer posts</a>{% else %}<span></span>{% endif %}
+    <span>page {{ paginator.page }} of {{ paginator.total_pages }}</span>
+    {% if paginator.next_page %}<a href="{{ paginator.next_page_path | relative_url }}">older posts »</a>{% else %}<span></span>{% endif %}
+  </footer>
+{% endif %}

--- a/assets/css/classes.sass
+++ b/assets/css/classes.sass
@@ -104,8 +104,3 @@
     width: 100%
 
 {% endunless %}
-
-.right-side
-  float: right
-  width: 20%
-  margin-left: 1em

--- a/assets/css/index.sass
+++ b/assets/css/index.sass
@@ -32,8 +32,3 @@ body > footer
   box-shadow: 0 0 .6em rgba($dark, 0.04) inset
 
 {% endunless %}
-
-.right-side
-  float: right
-  width: 20%
-  margin-left: 1em


### PR DESCRIPTION
Move the main page to the center.

* Remove the `div` with class `right-side` from `_includes/home.html` and `_includes/archive.html`.
* Update the `article` elements in `_includes/home.html` to be direct children of the main container.
* Update the `ul` element in `_includes/archive.html` to be a direct child of the main container.
* Remove the CSS class `right-side` from `assets/css/index.sass` and `assets/css/classes.sass`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/orkung/orkung.github.io/pull/5?shareId=42ced116-bd9d-4c83-9271-5ec31d5c2c9f).